### PR TITLE
8-Remove-dead-branch-of-if-in-TLVirtualNode

### DIFF
--- a/src/Telescope-Cytoscape-Tests/TLVirtualStructureTests.class.st
+++ b/src/Telescope-Cytoscape-Tests/TLVirtualStructureTests.class.st
@@ -7,9 +7,17 @@ Class {
 { #category : #tests }
 TLVirtualStructureTests >> testLayoutApplication [
 	| nodes |
-	nodes := (1 to: 10) collect: [ :i | TLVirtualNode new dimension: 5@8 ].
+	nodes := (1 to: 10)
+		collect: [ :i | 
+			TLVirtualNode new
+				dimension: 5 @ 8;
+				realNode:
+					((TLSimpleNode withEntity: i)
+						styleSheet: TLStyleSheet default;
+						yourself);
+				yourself ].
 	TLLinearLayout topToBottom on: nodes.
-	nodes do: [:aNode | self assert: aNode position notNil ]
+	nodes do: [ :aNode | self assert: aNode position notNil ]
 ]
 
 { #category : #tests }

--- a/src/Telescope-Cytoscape/TLVirtualNode.class.st
+++ b/src/Telescope-Cytoscape/TLVirtualNode.class.st
@@ -208,7 +208,7 @@ TLVirtualNode >> nodeId: anObject [
 
 { #category : #dimension }
 TLVirtualNode >> occupyMaxSpace [
-	^ self realNode ifNil: [ false ] ifNotNil: [ self realNode effectiveStyleSheet takeAllSpace ]
+	^ self realNode effectiveStyleSheet takeAllSpace
 ]
 
 { #category : #dimension }


### PR DESCRIPTION
Virtual nodes should always have a real node.

Fixes #8