### PR TITLE
36-TLCytoscapeConnector-as-undefined-subclass-responsibility

### DIFF
--- a/src/Telescope-Cytoscape/TLCytoscapeConnector.class.st
+++ b/src/Telescope-Cytoscape/TLCytoscapeConnector.class.st
@@ -184,6 +184,13 @@ TLCytoscapeConnector >> createLegendFrom: legendEnties [
 	"Nothing to do here"
 ]
 
+{ #category : #'generation - interaction' }
+TLCytoscapeConnector >> createMenuFor: aTLDrawable [
+	"Menu are managed in a different way in Cytoscape"
+
+	self shouldNotImplement
+]
+
 { #category : #'generation - node' }
 TLCytoscapeConnector >> define: parentCompositeElement asParentFor: aCollectionOfChildrenElements [
 	aCollectionOfChildrenElements parent: parentCompositeElement


### PR DESCRIPTION
Add #createMenuFor: in Cytoscape connector

Fixes #36