### PR TITLE
49-Remove-TLMemorizeNodePositionAction-related-code-since-its-removed-from-Telescope

### DIFF
--- a/src/Telescope-Cytoscape/TLVirtualNode.class.st
+++ b/src/Telescope-Cytoscape/TLVirtualNode.class.st
@@ -84,15 +84,6 @@ TLVirtualNode >> defineFixedPositionFromAbsolute: aPosition [
 	self defineFixedRelativePosition: (self calculateRelativePositionFromAbsolute: aPosition)
 ]
 
-{ #category : #position }
-TLVirtualNode >> defineFixedRelativePosition: aPosition [
-	self userFixedPosition: false.
-	aPosition
-		ifNotNil: [ 
-			self position: aPosition.
-			self userFixedPosition: true ]
-]
-
 { #category : #accessing }
 TLVirtualNode >> dimension [
 	^ self hasChildren
@@ -149,7 +140,6 @@ TLVirtualNode >> incomingAdjacentNodes [
 TLVirtualNode >> initialize [
 	super initialize.
 	self children: (TLVirtualGroup new composite: self).
-	self userFixedPosition: false.
 	triggers:= OrderedCollection new 
 ]
 
@@ -201,8 +191,7 @@ TLVirtualNode >> position [
 
 { #category : #accessing }
 TLVirtualNode >> position: anObject [
-	self userFixedPosition
-		ifFalse: [ position := anObject ].
+	position := anObject.
 	self clearEncompassingRectangle
 ]
 
@@ -238,16 +227,6 @@ TLVirtualNode >> restoreOriginalDimension [
 { #category : #accessing }
 TLVirtualNode >> triggers [
 	^ triggers
-]
-
-{ #category : #accessing }
-TLVirtualNode >> userFixedPosition [
-	^ userFixedPosition
-]
-
-{ #category : #accessing }
-TLVirtualNode >> userFixedPosition: anObject [
-	userFixedPosition := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Remove TLMemorizeNodePositionAction related code.

Fixes #49